### PR TITLE
Fix Unsupported Operation error in Tally widget

### DIFF
--- a/lib/widgets/tally.dart
+++ b/lib/widgets/tally.dart
@@ -27,6 +27,7 @@ class _AnimatedCountState extends AnimatedWidgetBaseState<Tally> {
   Widget build(BuildContext context) {
     var points = _points.evaluate(animation);
     var width = 3;
+    var percent = points / widget.max;
     return Column(
       children: <Widget>[
         Padding(
@@ -49,7 +50,7 @@ class _AnimatedCountState extends AnimatedWidgetBaseState<Tally> {
               decoration: BoxDecoration(border: Border.all(width: 2.0)),
               child: LinearProgressIndicator(
                 backgroundColor: Colors.yellow,
-                value: points / widget.max,
+                value: !percent.isFinite ? 0 : percent,
                 valueColor: AlwaysStoppedAnimation<Color>(Colors.black),
               ),
             ),


### PR DESCRIPTION
This fixes an exception printing in the console when hot-reloading the
application in the IDE:
```
════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following UnsupportedError was thrown building LinearProgressIndicator(100.0%, dirty, dependencies: [TickerMode, Directionality], state: _LinearProgressIndicatorState#50427(ticker inactive and muted)):
Unsupported operation: Infinity or NaN toInt

User-created ancestor of the error-causing widget was: 
  Container file:///Users/pieper/Projects/flutter_spelling_bee/lib/widgets/tally.dart:46:13
When the exception was thrown, this was the stack: 
#0      double.toInt (dart:core-patch/double.dart:192:36)
#1      double.round (dart:core-patch/double.dart:160:34)
#2      ProgressIndicator._buildSemanticsWrapper (package:flutter/src/material/progress_indicator.dart:110:51)
#3      _LinearProgressIndicatorState._buildIndicator (package:flutter/src/material/progress_indicator.dart:284:19)
#4      _LinearProgressIndicatorState.build (package:flutter/src/material/progress_indicator.dart:309:14)
...
```

It appears that `LinearProgressIndicator` calls `value.round()` which
throws an exception if the value is not finite (`NaN` or `Infinity`).

Modifications:
* We check whether our tally percentage is finite and pass in 0 instead
of `Nan` or `Infinity`.