### PR TITLE
Automatically clear word if too long

### DIFF
--- a/lib/blocs/game_bloc.dart
+++ b/lib/blocs/game_bloc.dart
@@ -68,6 +68,8 @@ class _Game {
 
   bool addLetter(String l) {
     if (word.value.length > Logic.MAX_WORD_LENGTH) {
+      _setTempMessage(Logic.wordTooLongMessage);
+      clear();
       return false;
     }
     _setWord(word.value + l);

--- a/lib/helpers/logic.dart
+++ b/lib/helpers/logic.dart
@@ -1,10 +1,12 @@
 import 'dart:collection';
 import 'dart:math';
 
+import 'package:spelling_bee/blocs/game_bloc.dart';
 import "package:trotter/trotter.dart";
 
 class Logic {
   static const int MAX_WORD_LENGTH = 17;
+  static Message wordTooLongMessage = Message("Too long!", true);
 
   static String sortWord(String word) {
     var list = word.split("");


### PR DESCRIPTION
When inputting a long word we now automatically remove it and display an
error message.

Let me know if this goes against bloc architecture standards. I haven't really read up on that yet.

![too_long](https://user-images.githubusercontent.com/1526881/66709773-d54eef80-ed1f-11e9-81a5-0cd414f14d68.gif)